### PR TITLE
Revert "Update kustomization files to v2.1.0 removing bases"

### DIFF
--- a/src/elasticsearch/clusterwide/kustomization.yaml
+++ b/src/elasticsearch/clusterwide/kustomization.yaml
@@ -1,8 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-resources:
+bases:
 - ../base/
+
+resources:
 - namespace.yaml
 
 namespace: operator-elasticsearch

--- a/src/etcd/base/kustomization.yaml
+++ b/src/etcd/base/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 commonAnnotations:
-  app.kubernetes.io/version: v0.9.4
   catalog.kubestack.com/heritage: kubestack.com/catalog/etcd
   catalog.kubestack.com/variant: base
+  app.kubernetes.io/version: v0.9.4
 
 commonLabels:
   app.kubernetes.io/component: operator

--- a/src/etcd/clusterwide/kustomization.yaml
+++ b/src/etcd/clusterwide/kustomization.yaml
@@ -3,10 +3,13 @@ kind: Kustomization
 
 namespace: operator-etcd
 
+bases:
+- ../base/
+
 commonAnnotations:
-  app.kubernetes.io/version: v0.9.4
   catalog.kubestack.com/heritage: kubestack.com/catalog/etcd
   catalog.kubestack.com/variant: clusterwide
+  app.kubernetes.io/version: v0.9.4
 
 commonLabels:
   app.kubernetes.io/component: operator
@@ -18,7 +21,6 @@ patchesStrategicMerge:
 - patch_deployment_sa_name.yaml
 
 resources:
-- ../base/
 - cluster_role_binding.yaml
 - cluster_role.yaml
 - namespace.yaml

--- a/src/memcached/base/kustomization.yaml
+++ b/src/memcached/base/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 commonAnnotations:
-  app.kubernetes.io/version: v0.2.1
   catalog.kubestack.com/heritage: kubestack.com/catalog/memcached
   catalog.kubestack.com/variant: base
+  app.kubernetes.io/version: v0.2.1
 
 commonLabels:
   app.kubernetes.io/component: operator

--- a/src/memcached/clusterwide/kustomization.yaml
+++ b/src/memcached/clusterwide/kustomization.yaml
@@ -1,12 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+bases:
+- ../base/
+
 namespace: operator-memcached
 
 commonAnnotations:
-  app.kubernetes.io/version: v0.2.1
   catalog.kubestack.com/heritage: kubestack.com/catalog/memcached
   catalog.kubestack.com/variant: clusterwide
+  app.kubernetes.io/version: v0.2.1
 
 commonLabels:
   app.kubernetes.io/component: operator
@@ -14,7 +17,6 @@ commonLabels:
   app.kubernetes.io/name: memcached
 
 resources:
-- ../base/
 - namespace.yaml
 - service_account.yaml
 - cluster_role.yaml

--- a/src/mongodb/clusterwide/kustomization.yaml
+++ b/src/mongodb/clusterwide/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+bases:
+- ../base/
+
 namespace: operator-mongodb
 
 commonLabels:
@@ -14,7 +17,6 @@ commonAnnotations:
   catalog.kubestack.com/variant: clusterwide
 
 resources:
-- ../base/
 - namespace.yaml
 - service_account.yaml
 - cluster_role.yaml

--- a/src/nginx/base/kustomization.yaml
+++ b/src/nginx/base/kustomization.yaml
@@ -4,9 +4,9 @@ kind: Kustomization
 namespace: ingress-nginx
 
 commonAnnotations:
-  app.kubernetes.io/version: v0.24.1
   catalog.kubestack.com/heritage: kubestack.com/catalog/nginx
   catalog.kubestack.com/variant: base
+  app.kubernetes.io/version: v0.24.1
 
 commonLabels:
   app.kubernetes.io/component: ingress-controller

--- a/src/nginx/default-ingress/kustomization.yaml
+++ b/src/nginx/default-ingress/kustomization.yaml
@@ -1,12 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+bases:
+- ../base/
+
 namespace: ingress-kbst-default
 
 commonAnnotations:
-  app.kubernetes.io/version: v0.24.1
   catalog.kubestack.com/heritage: kubestack.com/catalog/nginx
   catalog.kubestack.com/variant: default-ingress
+  app.kubernetes.io/version: v0.24.1
 
 commonLabels:
   app.kubernetes.io/component: ingress-controller
@@ -20,6 +23,3 @@ patchesJson6902:
     kind: Namespace
     name: ingress-nginx
     version: v1
-
-resources:
-- ../base/

--- a/src/postgresql/clusterwide/kustomization.yaml
+++ b/src/postgresql/clusterwide/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+bases:
+- ../base/
+
 namespace: operator-postgresql
 
 commonAnnotations:
@@ -17,6 +20,5 @@ patchesStrategicMerge:
 - patch-deployment-env.yaml
 
 resources:
-- ../base/
 - namespace.yaml
 - rbac.yaml

--- a/src/prometheus/clusterwide/kustomization.yaml
+++ b/src/prometheus/clusterwide/kustomization.yaml
@@ -1,6 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+bases:
+- ../base/
+
 namespace: operator-prometheus
 
 commonAnnotations:
@@ -14,6 +17,5 @@ commonLabels:
   app.kubernetes.io/name: prometheus
 
 resources:
-- ../base/
 - namespace.yaml
 - instance-cluster-role.yaml


### PR DESCRIPTION
Reverts pst/kbst-catalog#31 until https://github.com/kubernetes-sigs/kustomize/pull/1206 is released.