### PR TITLE
Make manifests compatible with kustomize 3.x

### DIFF
--- a/src/elasticsearch/clusterwide/patch-deployment-sysctl-namespace.yaml
+++ b/src/elasticsearch/clusterwide/patch-deployment-sysctl-namespace.yaml
@@ -2,6 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: elasticsearch-operator
+  namespace: operator
 spec:
   template:
       spec:

--- a/src/nginx/base/patch-replicas.yaml
+++ b/src/nginx/base/patch-replicas.yaml
@@ -2,5 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-ingress-controller
+  namespace: ingress-nginx
 spec:
   replicas: 2

--- a/src/nginx/default-ingress/kustomization.yaml
+++ b/src/nginx/default-ingress/kustomization.yaml
@@ -22,5 +22,6 @@ patchesJson6902:
   target:
     kind: Deployment
     name: nginx-ingress-controller
+    namespace: ingress-nginx
     group: apps
     version: v1


### PR DESCRIPTION
Bumping to the latest `kustomize` version requires specifying the `namespace` in the patch files whenever the `namespace` is specified in the `resource` files (relevant issue https://github.com/kubernetes-sigs/kustomize/issues/1332).

Will update `Dockerfile` and test matrix in a separate PR.