### PR TITLE
Support testing against kustomize 2.x and 3.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kustomize-version: ["2.0.3", "3.1.0", "3.2.3"]
 
     steps:
     - uses: actions/checkout@v1
@@ -20,7 +23,7 @@ jobs:
     - name: Build image
       env:
         DOCKER_BUILDKIT: 1
-      run: docker build --build-arg KUSTOMIZE_VERSION=2.0.3 -t python3-kustomize:latest .
+      run: docker build --build-arg KUSTOMIZE_VERSION=${{ matrix.kustomize-version }} -t python3-kustomize:${{ matrix.kustomize-version }} .
 
     #
     #
@@ -29,13 +32,13 @@ jobs:
       env:
           GIT_REF: ${{ github.ref }}
           GIT_SHA: ${{ github.sha }}
-      run: docker run -e GIT_REF -e GIT_SHA -v /home/runner/work/catalog/catalog:/github/workspace -w /github/workspace python3-kustomize:latest bash -c './dist.py'
+      run: docker run -e GIT_REF -e GIT_SHA -v /home/runner/work/catalog/catalog:/github/workspace -w /github/workspace python3-kustomize:${{ matrix.kustomize-version }} bash -c './dist.py'
 
     #
     #
     # Run test.py
     - name: Run test.py
-      run: docker run -v /home/runner/work/catalog/catalog:/github/workspace -w /github/workspace python3-kustomize:latest bash -c './test.py'
+      run: docker run -v /home/runner/work/catalog/catalog:/github/workspace -w /github/workspace python3-kustomize:${{ matrix.kustomize-version }} bash -c './test.py'
 
     #
     #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3
 
-ARG KUSTOMIZE_VERSION=2.0.3
+ARG KUSTOMIZE_VERSION=3.2.3
 
-RUN curl -Lso /usr/local/bin/kustomize https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 \
+RUN if dpkg --compare-versions "$KUSTOMIZE_VERSION" "lt" "3.2.1"; \
+    then export KUSTOMIZE_BINARY_PATH=https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 ; \
+    else export KUSTOMIZE_BINARY_PATH=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_kustomize.v${KUSTOMIZE_VERSION}_linux_amd64 ; \
+    fi && \
+    curl -Lso /usr/local/bin/kustomize ${KUSTOMIZE_BINARY_PATH} \
     && chmod +x /usr/local/bin/kustomize \
     && kustomize version

--- a/src/nginx/default-ingress/kustomization.yaml
+++ b/src/nginx/default-ingress/kustomization.yaml
@@ -22,6 +22,6 @@ patchesJson6902:
   target:
     kind: Deployment
     name: nginx-ingress-controller
-    namespace: ingress-nginx
+    namespace: ingress-kbst-default
     group: apps
     version: v1


### PR DESCRIPTION
This also fixes a namespace selector in the `nginx/default-ingress` patches.