### PR TITLE
Update Kustomize versions used during tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        kustomize-version: ["2.0.3", "3.1.0", "3.2.3"]
+        kustomize-version: ["3.2.3", "3.5.4"]
 
     steps:
     - uses: actions/checkout@v1
@@ -32,7 +32,7 @@ jobs:
       env:
           GIT_REF: ${{ github.ref }}
           GIT_SHA: ${{ github.sha }}
-      run: docker run -e GIT_REF -e GIT_SHA -v /home/runner/work/catalog/catalog:/github/workspace -w /github/workspace python3-kustomize:${{ matrix.kustomize-version }} bash -c './dist.py'
+      run: docker run -e GIT_REF -e GIT_SHA -v /home/runner/work/catalog/catalog:/github/workspace -w /github/workspace python:3 bash -c './dist.py'
 
     #
     #
@@ -43,21 +43,11 @@ jobs:
 
   upload-build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        kustomize-version: ["3.2.3"]
+
     needs: test-build
 
     steps:
     - uses: actions/checkout@v1
-
-    #
-    #
-    # Build image
-    - name: Build image
-      env:
-        DOCKER_BUILDKIT: 1
-      run: docker build --build-arg KUSTOMIZE_VERSION=${{ matrix.kustomize-version }} -t python3-kustomize:${{ matrix.kustomize-version}} .
 
     #
     #
@@ -66,7 +56,7 @@ jobs:
       env:
           GIT_REF: ${{ github.ref }}
           GIT_SHA: ${{ github.sha }}
-      run: docker run -e GIT_REF -e GIT_SHA -v /home/runner/work/catalog/catalog:/github/workspace -w /github/workspace python3-kustomize:${{ matrix.kustomize-version}} bash -c './dist.py'
+      run: docker run -e GIT_REF -e GIT_SHA -v /home/runner/work/catalog/catalog:/github/workspace -w /github/workspace python:3 bash -c './dist.py'
 
     #
     #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,44 @@
-FROM python:3
+FROM python:3 as base
 
-ARG KUSTOMIZE_VERSION=3.2.3
+#
+#
+# tmp image to handle kustomize changing release artifacts
+FROM base as tmp
 
-RUN if dpkg --compare-versions "$KUSTOMIZE_VERSION" "lt" "3.2.1"; \
-    then export KUSTOMIZE_BINARY_PATH=https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 ; \
-    else export KUSTOMIZE_BINARY_PATH=https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_kustomize.v${KUSTOMIZE_VERSION}_linux_amd64 ; \
-    fi && \
-    curl -Lso /usr/local/bin/kustomize ${KUSTOMIZE_BINARY_PATH} \
-    && chmod +x /usr/local/bin/kustomize \
-    && kustomize version
+ARG KUSTOMIZE_VERSION=3.5.4
+
+WORKDIR /tmp
+
+# Reject kustomize versions before 3.2.1
+RUN if dpkg --compare-versions "$KUSTOMIZE_VERSION" "lt" "3.2.1"; then \
+      echo "kustomize versions lower than 3.2.1 not supported" && \
+      exit; \
+    fi
+
+# Handle kustomize versions before 3.3.0
+# distributed as binaries
+RUN if dpkg --compare-versions "$KUSTOMIZE_VERSION" "lt" "3.3.0"; then \
+      KUSTOMIZE_BINARY_PATH="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_kustomize.v${KUSTOMIZE_VERSION}_linux_amd64"; \
+      curl -Lso /usr/local/bin/kustomize ${KUSTOMIZE_BINARY_PATH} && \
+      chmod +x /usr/local/bin/kustomize && \
+      kustomize version; \
+    fi
+
+# Handle kustomize versions after 3.3.0
+# distributed as tar files
+RUN if dpkg --compare-versions "$KUSTOMIZE_VERSION" "ge" "3.3.0"; \
+    then \
+      KUSTOMIZE_BINARY_PATH="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"; \
+      curl -LOs ${KUSTOMIZE_BINARY_PATH} && \
+      tar -xf kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
+      mv kustomize /usr/local/bin/kustomize && \
+      chmod +x /usr/local/bin/kustomize && \
+      kustomize version; \
+    fi
+
+#
+#
+# final image
+FROM base
+
+COPY --from=tmp /usr/local/bin/kustomize /usr/local/bin/kustomize


### PR DESCRIPTION
 * test last version before the big kustomize refactoring 3.2.3
 * and the latest version 3.5.4
 * do not test 2.x.x versions anymore
 * extend Dockerfile to handle kustomize again changing
   release artifacts
 * run dist.py in the vanilla python:3 image, kustomize is
   not needed for dist