### PR TITLE
Remove kubectl -k from release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     #
     #
     # Setup Kind
-    - uses: engineerd/setup-kind@v0.1.0
+    - uses: engineerd/setup-kind@v0.3.0
 
     #
     #
@@ -34,10 +34,50 @@ jobs:
 
     #
     #
+    # Get binaries
+    - name: Get binaries
+      env:
+          TERRAFORM_VERSION: 0.12.24
+          TERRAFORM_PROVIDER_KUSTOMIZE_VERSION: v0.1.0-beta.3
+      run: |
+        echo "TERRAFORM_VERSION: ${TERRAFORM_VERSION}"
+        curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+        unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /opt/bin
+        chmod +x /opt/bin/terraform
+        /opt/bin/terraform version
+        rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+        echo
+        echo
+        echo "TERRAFORM_PROVIDER_KUSTOMIZE_VERSION: ${TERRAFORM_PROVIDER_KUSTOMIZE_VERSION}"
+        mkdir -p terraform.d/plugins/linux_amd64
+        curl -LO https://github.com/kbst/terraform-provider-kustomize/releases/download/${TERRAFORM_PROVIDER_KUSTOMIZE_VERSION}/terraform-provider-kustomization-${TERRAFORM_PROVIDER_KUSTOMIZE_VERSION}-linux-amd64
+        mv terraform-provider-kustomization-${TERRAFORM_PROVIDER_KUSTOMIZE_VERSION}-linux-amd64 terraform.d/plugins/linux_amd64/terraform-provider-kustomization
+        chmod +x terraform.d/plugins/linux_amd64/terraform-provider-kustomization
+
+    #
+    #
+    # Write test.tf.tpl
+    # data "kustomization" "test" {
+    #   # path to kustomization directory
+    #   path = ""
+    # }
+    #
+    # resource "kustomization_resource" "test" {
+    #   for_each = data.kustomization.test.ids
+    #
+    #   manifest = data.kustomization.test.manifests[each.value]
+    # }
+    - name: Write test.tf.tpl
+      run: |
+        echo "ZGF0YSAia3VzdG9taXphdGlvbiIgInRlc3QiIHsKICAjIHBhdGggdG8ga3VzdG9taXphdGlvbiBkaXJlY3RvcnkKICBwYXRoID0gIiIKfQoKcmVzb3VyY2UgImt1c3RvbWl6YXRpb25fcmVzb3VyY2UiICJ0ZXN0IiB7CiAgZm9yX2VhY2ggPSBkYXRhLmt1c3RvbWl6YXRpb24udGVzdC5pZHMKCiAgbWFuaWZlc3QgPSBkYXRhLmt1c3RvbWl6YXRpb24udGVzdC5tYW5pZmVzdHNbZWFjaC52YWx1ZV0KfQo=" | base64 --decode > test.tf.tpl
+
+    #
+    #
     # Deploy to cluster
     - name: Deploy
       run: |
-            export KUBECONFIG="$(kind get kubeconfig-path)"
+            export PATH=$PATH:/opt/bin
+
             kubectl version
             kubectl cluster-info
 
@@ -45,14 +85,18 @@ jobs:
             do
                 for overlay in $(ls _test/$entry)
                 do
+                    sed 's#path = ""#path = "_test/'${entry}'/'${overlay}'"#g' test.tf.tpl > test.tf
+
+                    terraform init
+
                     echo && echo '### TEST APPLY ###'
-                    kubectl apply -k _test/$entry/$overlay
+                    terraform apply --auto-approve
 
                     echo && echo '### TEST READY ###'
                     kubectl wait pod --for=condition=Ready --timeout=300s --all --all-namespaces
 
                     echo && echo '### TEST DELETE ###'
-                    kubectl delete -k _test/$entry/$overlay --wait
+                    terraform destroy --auto-approve
                 done
             done
 


### PR DESCRIPTION
The kustomize version included in kubectl is outdated and many
bugs that have since been fixed in kustomize are still in kubectl.