### PR TITLE
Use https instead of SSH for cert-manager github repo url

### DIFF
--- a/src/cert-manager/_updater/metadata.yaml
+++ b/src/cert-manager/_updater/metadata.yaml
@@ -1,1 +1,1 @@
-url: git@github.com:jetstack/cert-manager.git
+url: https://github.com/jetstack/cert-manager.git


### PR DESCRIPTION
The nightly Github Action running the updater, only configures
authentication for the https, not the SSH git transport.