### PR TITLE
Set default namespace for postgresql base

### DIFF
--- a/src/postgresql/base/kustomization.yaml
+++ b/src/postgresql/base/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: default
 commonAnnotations:
   app.kubernetes.io/version: v1.5.0
   catalog.kubestack.com/heritage: kubestack.com/catalog/postgresql


### PR DESCRIPTION
Upstream does not set a namespace and the
terraform-provider-kustomize does not, unlike, kubectl fall back
to the default namespace automatically.

Being explicit here seems a better choice and should meet
expected behaviour for people used to kubectl.