### PR TITLE
Increase parallelism to fix flaky tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
                     terraform init
 
                     echo && echo '### TEST APPLY ###'
-                    terraform apply --auto-approve
+                    terraform apply --auto-approve --parallelism=30
 
                     echo && echo '### TEST READY ###'
                     kubectl wait pod --for=condition=Ready --timeout=300s --all --all-namespaces


### PR DESCRIPTION
The `terraform-kustomize-provider` has an edge case where due to
the lack of dependencies between resources it is possible, that
all 10 default resources are waiting for e.g. a namespace to
be created, but the namespace is the 11th resource.

One workaround is, to increase the parallelism. Alternatively,
dependencies could be specified explicitly, but this isn't
viable for the test scenario here.

More details: https://github.com/kbst/terraform-provider-kustomize/issues/36