### PR TITLE
Fix nginx releases setting namespace for cluster-wide resources

### DIFF
--- a/src/nginx/base/mandatory.yaml
+++ b/src/nginx/base/mandatory.yaml
@@ -48,7 +48,6 @@ metadata:
     app.kubernetes.io/version: 0.34.1
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx
-  namespace: ingress-nginx
 rules:
   - apiGroups:
       - ''
@@ -119,7 +118,6 @@ metadata:
     app.kubernetes.io/version: 0.34.1
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx
-  namespace: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -423,7 +421,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
   name: ingress-nginx-admission
-  namespace: ingress-nginx
 webhooks:
   - name: validate.nginx.ingress.kubernetes.io
     rules:
@@ -463,7 +460,6 @@ metadata:
     app.kubernetes.io/version: 0.34.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
-  namespace: ingress-nginx
 rules:
   - apiGroups:
       - admissionregistration.k8s.io
@@ -488,7 +484,6 @@ metadata:
     app.kubernetes.io/version: 0.34.1
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
-  namespace: ingress-nginx
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Upstream fixed that release artifacts had `namespace` set for
resources which are not namespaced (e.g. the ClusterRole).

This commit backports this for the nginx-v0.34.1-kbst.0 release.

https://github.com/kubernetes/ingress-nginx/pull/5946