### PR TITLE
Remove hardcoded base version code

### DIFF
--- a/.github/actions/updater/updater/catalog.py
+++ b/.github/actions/updater/updater/catalog.py
@@ -120,10 +120,6 @@ class Catalog():
         if not script_success:
             return
 
-        # update or set version annotation on base
-        base_path = path.join(target_path, 'base')
-        self.update_version_annotation(base_path, release_version)
-
         # update or set version annotation on all variants
         for variant in self.get_variants(entry):
             variant_path = path.join(target_path, variant)


### PR DESCRIPTION
This breaks fro ArgoCD, which has no one base due to the way upstream
distributes different variants.

Also, the hardcoded base version annotation update code is not needed.
The code handling all variants will handle base just fine.