### PR TITLE
Filter sealed secrets releases

### DIFF
--- a/src/sealed-secrets/_updater/metadata.yaml
+++ b/src/sealed-secrets/_updater/metadata.yaml
@@ -1,1 +1,2 @@
 url: https://github.com/bitnami-labs/sealed-secrets.git
+filter_tags: ^sealed-secrets-(.*)


### PR DESCRIPTION
Upstream has started to prefix releases with `sealed-secrets-`
and `helm-`. This commit filters out the helm releases and
removes the prefix from the version.