### PR TITLE
Add generic kustomization module for custom manifests

### DIFF
--- a/src/_terraform_module/data_source.tf
+++ b/src/_terraform_module/data_source.tf
@@ -113,5 +113,5 @@ data "kustomization_overlay" "current" {
     }
   }
 
-  resources = concat(["${path.module}/${local.variant}/"], local.additional_resources)
+  resources = local.cfg["resources"] != null ? local.cfg["resources"] : concat(["${path.module}/${local.variant}/"], local.additional_resources)
 }

--- a/src/_terraform_module/variables_shared.tf
+++ b/src/_terraform_module/variables_shared.tf
@@ -6,9 +6,13 @@ variable "configuration" {
     # Each module has a default_variant
     variant = optional(string)
 
-    # Modules don't expose Kustomization's resource
-    # attribute, but only allow adding additional
-    # resources to the list
+    # if set, will overwrite all of the module's
+    # upstream resources, only useful in edge cases
+    # see additional_resources instead
+    resources = optional(list(string))
+
+    # concat additional resources to the list of
+    # included upstream resources
     additional_resources = optional(list(string))
 
     # Below are all Kustomization built-in

--- a/src/custom-manifests/configuration.tf
+++ b/src/custom-manifests/configuration.tf
@@ -1,0 +1,1 @@
+../_terraform_module/configuration.tf

--- a/src/custom-manifests/data_source.tf
+++ b/src/custom-manifests/data_source.tf
@@ -1,0 +1,1 @@
+../_terraform_module/data_source.tf

--- a/src/custom-manifests/default_variant.tf
+++ b/src/custom-manifests/default_variant.tf
@@ -1,0 +1,3 @@
+locals {
+  default_variant = "empty"
+}

--- a/src/custom-manifests/empty/Kustomization
+++ b/src/custom-manifests/empty/Kustomization
@@ -1,0 +1,2 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/src/custom-manifests/main.tf
+++ b/src/custom-manifests/main.tf
@@ -1,0 +1,1 @@
+../_terraform_module/main._tf

--- a/src/custom-manifests/variables_shared.tf
+++ b/src/custom-manifests/variables_shared.tf
@@ -1,0 +1,1 @@
+../_terraform_module/variables_shared.tf

--- a/src/custom-manifests/versions.tf
+++ b/src/custom-manifests/versions.tf
@@ -1,0 +1,1 @@
+../_terraform_module/versions.tf


### PR DESCRIPTION
Also adds previously omitted ability to entirely overwrite
the Kustomize resources attribute to all modules.

In most cases using additional_resources will most likely
still be more useful.